### PR TITLE
運動頁面新增實時顯示GPS和距離，及跑步健走兩種模式計算消耗卡路里、總距離和計時功能

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.luce.healthmanager">
-
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/chat_foreground"

--- a/app/src/main/java/com/luce/healthmanager/ExerciseFragment.java
+++ b/app/src/main/java/com/luce/healthmanager/ExerciseFragment.java
@@ -1,97 +1,182 @@
 package com.luce.healthmanager;
 
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.location.Location;
+import android.location.LocationListener;
+import android.location.LocationManager;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.SystemClock;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
+
+import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.Fragment;
+
+import java.util.Locale;
 
 public class ExerciseFragment extends Fragment {
 
     private boolean isRunning = false;
+    private boolean isRunMode = false;
+    private LocationManager locationManager;
+    private LocationListener locationListener;
+    private double totalDistance = 0.0;
+    private long startTime = 0;
+    private Handler handler = new Handler();
+    private Runnable updateTimerRunnable;
+
+    private TextView exerciseDistance;
+    private TextView exerciseTime;
+    private TextView caloriesBurned;
+    private Button btnRun;
+    private Button btnWalk;
+    private Button startButton;
+
+    private double lastLatitude = 0.0;
+    private double lastLongitude = 0.0;
+    private boolean isFirstLocation = true;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_exercise, container, false);
 
-        // 設置運動數據
-        TextView exerciseDistance = view.findViewById(R.id.exercise_distance);
-        TextView exerciseStatus = view.findViewById(R.id.exercise_status);  // 單一TextView顯示運動狀態
-        TextView exerciseTime = view.findViewById(R.id.exercise_time);
-        TextView caloriesBurned = view.findViewById(R.id.calories_burned);
+        // 在這裡初始化 LocationManager
+        locationManager = (LocationManager) getActivity().getSystemService(Context.LOCATION_SERVICE);
 
-        // 初始化按鈕
-        Button btnRun = view.findViewById(R.id.btn_run);
-        Button btnWalk = view.findViewById(R.id.btn_walk);
-        Button startButton = view.findViewById(R.id.start_exercise_button);
+        // 初始化視圖
+        exerciseDistance = view.findViewById(R.id.exercise_distance);
+        exerciseTime = view.findViewById(R.id.exercise_time);
+        caloriesBurned = view.findViewById(R.id.calories_burned);
+        btnRun = view.findViewById(R.id.btn_run);
+        btnWalk = view.findViewById(R.id.btn_walk);
+        startButton = view.findViewById(R.id.start_exercise_button);
 
         // 跑步按鈕點擊事件
         btnRun.setOnClickListener(v -> {
-            btnWalk.setBackgroundResource(R.color.colorPrimaryDark);  // 恢復默認背景顏色
-            btnRun.setBackgroundResource(R.color.colorPrimary);  // 設定跑步按鈕背景色
-            exerciseStatus.setText("跑步");
-
-            // 更新數據，從穿戴裝置取得數據
-            double distance = getWearableDeviceDistance();
-            //int calories = calculateCalories(distance, "run"); // 根據運動模式計算卡路里
-            exerciseDistance.setText(String.format("%.1f 公里", distance));
-            caloriesBurned.setText(String.format("消耗卡路里：%d"));
+            btnRun.setBackgroundResource(R.color.colorPrimary); // 選中的
+            btnWalk.setBackgroundResource(R.color.colorPrimaryDark); // 恢復另一個按鈕的顏色
+            isRunMode = true;
         });
 
         // 健走按鈕點擊事件
         btnWalk.setOnClickListener(v -> {
-            btnWalk.setBackgroundResource(R.color.colorPrimaryDark);  // 設定健走按鈕背景色
-            btnRun.setBackgroundResource(R.color.colorPrimary);  // 恢復默認背景顏色
-            exerciseStatus.setText("健走");
-
-            // 更新數據，從穿戴裝置取得數據
-            double distance = getWearableDeviceDistance();
-            //int calories = calculateCalories(distance, "walk"); // 根據運動模式計算卡路里
-            exerciseDistance.setText(String.format("%.1f 公里", distance));
-            caloriesBurned.setText(String.format("消耗卡路里：%d"));
+            btnWalk.setBackgroundResource(R.color.colorPrimary); // 選中
+            btnRun.setBackgroundResource(R.color.colorPrimaryDark); // 恢復另一個按鈕的顏色
+            isRunMode = false;
         });
 
         // 開始運動按鈕點擊事件
         startButton.setOnClickListener(v -> {
             if (isRunning) {
-                // 如果已經在運動中，則暫停運動
                 isRunning = false;
                 startButton.setText("GO");
-                pauseExercise();  // 暫停運動邏輯
+                pauseExercise();
             } else {
-                // 如果沒有在運動，則開始運動
                 isRunning = true;
                 startButton.setText("STOP");
-                startExercise();  // 開始運動邏輯
+                startExercise();
             }
         });
 
         return view;
     }
 
-
-    // 假設是開始運動的邏輯
+    // 開始運動的邏輯
     private void startExercise() {
-        // 這裡是開始運動的具體實現邏輯，可以是計時器開始、運動數據更新等
-        // 例如：
-        // timer.start();
+        startTime = SystemClock.elapsedRealtime();
+        updateTimerRunnable = new Runnable() {
+            @Override
+            public void run() {
+                long elapsedTime = SystemClock.elapsedRealtime() - startTime;
+                int minutes = (int) (elapsedTime / 1000 / 60);
+                int seconds = (int) (elapsedTime / 1000 % 60);
+                exerciseTime.setText(String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds));
+                handler.postDelayed(this, 1000); // 每秒更新一次
+            }
+        };
+        handler.post(updateTimerRunnable);
+
+        // 初始化 LocationListener
+        locationListener = new LocationListener() {
+            @Override
+            public void onLocationChanged(Location location) {
+                // 計算新的距離並更新界面
+                if (isRunning) {
+                    double currentLatitude = location.getLatitude();
+                    double currentLongitude = location.getLongitude();
+                    totalDistance += calculateDistance(currentLatitude, currentLongitude); // 自行實現距離計算邏輯
+                    exerciseDistance.setText(String.format(Locale.getDefault(), "%.2f 公里", totalDistance / 1000));
+                }
+            }
+
+            @Override
+            public void onStatusChanged(String provider, int status, Bundle extras) {}
+
+            @Override
+            public void onProviderEnabled(String provider) {}
+
+            @Override
+            public void onProviderDisabled(String provider) {}
+        };
+
+        if (ActivityCompat.checkSelfPermission(getActivity(), Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(getActivity(), Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+            requestPermissions(new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, 1);
+            return;
+        }
+
+        locationManager.requestLocationUpdates(LocationManager.GPS_PROVIDER, 5000, 0, locationListener); // 每分鐘更新一次位置
+        // 在開始新的運動時重置距離和卡路里
+        totalDistance = 0.0;
+        exerciseDistance.setText(String.format(Locale.getDefault(), "%.2f 公里", totalDistance / 1000));
+        caloriesBurned.setText("消耗卡路里：0");
+
     }
 
-    // 假設是暫停運動的邏輯
+
+    // 暫停運動的邏輯
     private void pauseExercise() {
-        // 這裡是暫停運動的具體實現邏輯，停止計時器或暫停數據更新等
-        // 例如：
-        // timer.pause();
+        handler.removeCallbacks(updateTimerRunnable);
+        locationManager.removeUpdates(locationListener);
+
+        int calories = calculateCalories(totalDistance / 1000);
+        caloriesBurned.setText(String.format("消耗卡路里：%d", calories));
+        //調用一個方法（待製作）來將數據傳送給後端寫入資料庫供AI-Service使用，要先討論想使用什麼技術和步驟
     }
 
-    // 假設從穿戴裝置取得距離數據
-    private double getWearableDeviceDistance() {
-        // 在此處從小米穿戴式裝置取得實際距離數據的邏輯
-        // 這裡暫時返回固定數據作為示範
-        return 5.0;  // 例如：5公里
+    // 根據運動模式計算卡路里
+    private int calculateCalories(double distance) {
+        return isRunMode ? (int) (distance * 120) : (int) (distance * 80); // 假設跑步每公里120卡路里，健走每公里80卡路里
     }
+
+
+    // 計算兩個地理位置之間的距離
+    private double calculateDistance(double currentLatitude, double currentLongitude) {
+        if (isFirstLocation) {
+            // 如果是第一次獲取位置，設置為初始位置
+            lastLatitude = currentLatitude;
+            lastLongitude = currentLongitude;
+            isFirstLocation = false;
+            return 0;
+        }
+
+        // 定義一個用來存儲結果的數組
+        float[] results = new float[1];
+
+        // 計算兩點間的距離，並存儲在 results[0] 中
+        Location.distanceBetween(lastLatitude, lastLongitude, currentLatitude, currentLongitude, results);
+
+        // 更新最後的位置
+        lastLatitude = currentLatitude;
+        lastLongitude = currentLongitude;
+
+        // 返回距離，單位是米
+        return results[0];
+    }
+
 }
-
-// 根據

--- a/app/src/main/res/layout/fragment_exercise.xml
+++ b/app/src/main/res/layout/fragment_exercise.xml
@@ -97,7 +97,7 @@
                         android:id="@+id/exercise_distance"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="已進行：26.8 公里"
+                        android:text="已進行：0.0 公里"
                         android:textSize="16sp" />
 
                     <!-- 運動時間 -->
@@ -105,7 +105,7 @@
                         android:id="@+id/exercise_time"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="運動時間：45分鐘"
+                        android:text="運動時間：0分鐘"
                         android:textSize="16sp" />
 
                     <!-- 消耗卡路里 -->
@@ -113,7 +113,7 @@
                         android:id="@+id/calories_burned"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="消耗卡路里：300"
+                        android:text="消耗卡路里：0"
                         android:textSize="16sp" />
 
                 </LinearLayout>


### PR DESCRIPTION
新增選擇跑步、步行兩種模式後點擊開始後即時顯示距離及時間，並在點擊停止後顯示總距離及總時間和消耗相關
修改距離和消耗能力顯示數字
新增取得位置權限
#resolves #13
待實現功能：每次運動後將數據發送到後端，來產生週報年報或給AI-Service調用
